### PR TITLE
Add clap api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,7 +42,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "psql_connect"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "clap 2.31.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psql_connect"
-version = "0.0.1"
+version = "0.0.2"
 authors = ["Ryan B <notryanb@gmail.com>"]
 
 [dependencies]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 extern crate clap;
 
-// use clap::{Arg, App, SubCommand};
+use clap::{Arg, App, SubCommand};
 
 mod pg_pass;
 
@@ -8,15 +8,37 @@ use std::process::Command;
 use self::pg_pass::*;
 
 fn main() -> std::io::Result<()> {
-    println!("Yo!");
     let result = parse_pg_pass()?;
-    // let config = &result.configs[0];
 
-    let aliases = result.list_aliases();
-    let selected = result.select_config("mlr-staging");
-    println!("Config: {:?}", selected);
+    let matches = App::new("Psql Connect")
+        .version("0.1")
+        .author("Ryan Blecher <notryanb@gmail.com")
+        .about("Easily connect to a postgres database configured via a `.pg_pass` file")
+        .arg(Arg::with_name("list")
+             .short("l")
+             .long("list")
+             .help("Lists all database connections by number and alias"))
+        .arg(Arg::with_name("connect")
+             .short("c")
+             .long("connect")
+             .value_name("alias")
+             .help("Connects to a alias provided in `.pg_pass` file")
+             .takes_value(true))
+        .get_matches();
 
-    // connect_to_config(&config);
+    if matches.is_present("list") {
+        let aliases = result.list_aliases();
+        aliases.iter()
+            .enumerate()
+            .for_each(|(idx, alias)| println!("{}: {}", idx + 1, alias.unwrap()));
+    }
+
+    if let Some(alias) = matches.value_of("connect") {
+        let selected = result.select_config(alias).unwrap();
+        println!("Connecting to: {}", alias);
+        connect_to_config(&selected);
+    }
+
 
     println!("Exiting psql_connect");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 extern crate clap;
 
-use clap::{Arg, App, SubCommand};
+use clap::{App, Arg, SubCommand};
 
 mod pg_pass;
 
@@ -11,24 +11,29 @@ fn main() -> std::io::Result<()> {
     let result = parse_pg_pass()?;
 
     let matches = App::new("Psql Connect")
-        .version("0.1")
+        .version("0.0.2")
         .author("Ryan Blecher <notryanb@gmail.com")
         .about("Easily connect to a postgres database configured via a `.pg_pass` file")
-        .arg(Arg::with_name("list")
-             .short("l")
-             .long("list")
-             .help("Lists all database connections by number and alias"))
-        .arg(Arg::with_name("connect")
-             .short("c")
-             .long("connect")
-             .value_name("alias")
-             .help("Connects to a alias provided in `.pg_pass` file")
-             .takes_value(true))
+        .arg(
+            Arg::with_name("list")
+                .short("l")
+                .long("list")
+                .help("Lists all database connections by number and alias"),
+        )
+        .arg(
+            Arg::with_name("connect")
+                .short("c")
+                .long("connect")
+                .value_name("alias")
+                .help("Connects to a alias provided in `.pg_pass` file")
+                .takes_value(true),
+        )
         .get_matches();
 
     if matches.is_present("list") {
         let aliases = result.list_aliases();
-        aliases.iter()
+        aliases
+            .iter()
             .enumerate()
             .for_each(|(idx, alias)| println!("{}: {}", idx + 1, alias.unwrap()));
     }
@@ -39,23 +44,19 @@ fn main() -> std::io::Result<()> {
         connect_to_config(&selected);
     }
 
-
-    println!("Exiting psql_connect");
-
     Ok(())
 }
 
 pub fn connect_to_config(config: &PgConfig) {
     let psql = Command::new("psql")
         .arg("-w")
-        .arg(format!("--host={}", config.hostname ))
-        .arg(format!("--port={}", config.port ))
-        .arg(format!("--username={}", config.username ))
-        .arg(format!("--dbname={}", config.dbname ))
+        .arg(format!("--host={}", config.hostname))
+        .arg(format!("--port={}", config.port))
+        .arg(format!("--username={}", config.username))
+        .arg(format!("--dbname={}", config.dbname))
         .spawn()
         .expect("failed to execute process");
 
     let output = psql.wait_with_output().expect("Couldn't wait on `psql`");
     output.stdout;
 }
-

--- a/src/pg_pass.rs
+++ b/src/pg_pass.rs
@@ -10,26 +10,21 @@ pub struct PgConfigList {
 
 impl PgConfigList {
     pub fn new() -> PgConfigList {
-        PgConfigList { 
+        PgConfigList {
             configs: Vec::new(),
         }
     }
 
     pub fn add(&mut self, config: PgConfig) {
-        self.configs.push(config); 
+        self.configs.push(config);
     }
 
     pub fn list_aliases(&self) -> Vec<Option<&String>> {
-        self
-            .configs
-            .iter()
-            .map(|cfg| cfg.alias.as_ref())
-            .collect()
+        self.configs.iter().map(|cfg| cfg.alias.as_ref()).collect()
     }
 
     pub fn select_config(&self, alias: &str) -> Option<&PgConfig> {
-        let config: Vec<_> = self
-            .configs
+        let config: Vec<_> = self.configs
             .iter()
             .filter(|cfg| cfg.alias.as_ref().unwrap() == alias)
             .collect();
@@ -39,7 +34,6 @@ impl PgConfigList {
             1 => Some(config[0]),
             _ => None,
         }
-
     }
 }
 
@@ -95,7 +89,7 @@ mod tests {
         let result = config_list.select_config("test");
         assert_eq!(result, None);
     }
-    
+
     #[test]
     fn selecting_existing_config() {
         let config = PgConfig {
@@ -106,7 +100,7 @@ mod tests {
             username: "test".into(),
             password: "test".into(),
         };
-        
+
         let expected = PgConfig {
             alias: Some("test".into()),
             hostname: "test".into(),
@@ -116,7 +110,9 @@ mod tests {
             password: "test".into(),
         };
 
-        let config_list = PgConfigList { configs: vec![config] };
+        let config_list = PgConfigList {
+            configs: vec![config],
+        };
         let result = config_list.select_config("test").unwrap();
         assert_eq!(*result, expected);
     }


### PR DESCRIPTION
Add very basic arg parsing without any error detection. Error detection will be added in the next PR once the API is slightly expanded.